### PR TITLE
Allow displaying time-based CPU usage

### DIFF
--- a/src/absim.hpp
+++ b/src/absim.hpp
@@ -800,14 +800,24 @@ struct arduboy_t
     std::array<uint64_t, NUM_INSTRS> profiler_counts;
     uint64_t profiler_total;
     uint64_t profiler_total_with_sleep;
+
     // counts for previous frame
     uint64_t prev_profiler_total;
     uint64_t prev_profiler_total_with_sleep;
     uint64_t prev_frame_cycles;
     uint32_t total_frames;
+    uint32_t total_ms;
     uint32_t frame_bytes_total;
     uint32_t frame_bytes;
     std::vector<float> frame_cpu_usage;
+
+    // time-based cpu usage
+    std::vector<float> ms_cpu_usage_raw;
+    std::vector<float> ms_cpu_usage;
+    uint64_t prev_profiler_total_ms;
+    uint64_t prev_profiler_total_with_sleep_ms;
+    uint64_t prev_ms_cycles;
+
     bool profiler_enabled;
     
     uint64_t cached_profiler_total;

--- a/src/absim_snapshot.cpp
+++ b/src/absim_snapshot.cpp
@@ -240,9 +240,12 @@ static std::string serdes_snapshot(Archive& ar, arduboy_t& a)
     ar(a.profiler_total_with_sleep);
     ar(a.prev_frame_cycles);
     ar(a.total_frames);
+    ar(a.prev_ms_cycles);
+    ar(a.total_ms);
     ar(a.frame_bytes_total);
     ar(a.frame_bytes);
     ar(a.frame_cpu_usage);
+    ar(a.ms_cpu_usage);
     ar(a.profiler_enabled);
     ar(a.cached_profiler_total);
     ar(a.cached_profiler_total_with_sleep);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -55,6 +55,7 @@ static void settings_read_line(
     ARDENS_BOOL_SETTING(record_wav);
     ARDENS_BOOL_SETTING(recording_sameasdisplay);
     ARDENS_BOOL_SETTING(nondeterminism);
+    ARDENS_BOOL_SETTING(frame_based_cpu_usage);
 
     ARDENS_BOOL_SETTING(ab.stack_overflow);
     ARDENS_BOOL_SETTING(ab.null_deref);
@@ -125,6 +126,7 @@ static void settings_write_all(ImGuiContext* ctx, ImGuiSettingsHandler* handler,
     ARDENS_BOOL_SETTING(record_wav);
     ARDENS_BOOL_SETTING(recording_sameasdisplay);
     ARDENS_BOOL_SETTING(nondeterminism);
+    ARDENS_BOOL_SETTING(frame_based_cpu_usage);
 
     ARDENS_BOOL_SETTING(ab.stack_overflow);
     ARDENS_BOOL_SETTING(ab.null_deref);

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -56,6 +56,7 @@ struct settings_t
     bool profiler_group_symbols = false;
     bool enable_step_breaks = true;
     bool nondeterminism = false;
+    bool frame_based_cpu_usage = true;
 
     struct
     {

--- a/src/window_cpu_usage.cpp
+++ b/src/window_cpu_usage.cpp
@@ -8,8 +8,6 @@
 
 extern std::unique_ptr<absim::arduboy_t> arduboy;
 
-static bool frame_based = true;
-
 static int xaxis_ms_formatter(double value, char* buf, int size, void* user)
 {
     (void)user;
@@ -25,6 +23,8 @@ static int yaxis_formatter(double value, char* buf, int size, void* user)
 static void window_contents()
 {
     using namespace ImPlot;
+
+    bool& frame_based = settings.frame_based_cpu_usage;
 
     if(!arduboy)
         return;

--- a/src/window_cpu_usage.cpp
+++ b/src/window_cpu_usage.cpp
@@ -8,6 +8,14 @@
 
 extern std::unique_ptr<absim::arduboy_t> arduboy;
 
+static bool frame_based = true;
+
+static int xaxis_ms_formatter(double value, char* buf, int size, void* user)
+{
+    (void)user;
+    return snprintf(buf, (size_t)size, "%.1f", value * 0.02);
+}
+
 static int yaxis_formatter(double value, char* buf, int size, void* user)
 {
     (void)user;
@@ -18,21 +26,27 @@ static void window_contents()
 {
     using namespace ImPlot;
 
-    if(arduboy->frame_cpu_usage.empty())
+    if(!arduboy)
+        return;
+    if(!frame_based && arduboy->ms_cpu_usage.empty() ||
+        frame_based && arduboy->frame_cpu_usage.empty())
         return;
 
     {
         float usage = 0.f;
         size_t i;
-        for(i = 0; i < 16; ++i)
+        size_t n = frame_based ? 16 : 3;
+        auto const& d = frame_based ? arduboy->frame_cpu_usage : arduboy->ms_cpu_usage;
+        for(i = 0; i < n; ++i)
         {
-            if(i >= arduboy->frame_cpu_usage.size())
+            if(i >= d.size())
                 break;
-            usage += arduboy->frame_cpu_usage[arduboy->frame_cpu_usage.size() - i - 1];
+            usage += d[d.size() - i - 1];
         }
-        usage /= i;
-        bool red = arduboy->frame_cpu_usage.back() > 0.999;
+        usage /= n;
+        bool red = usage > 0.999f;
         if(red) ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 0, 0, 255));
+        ImGui::AlignTextToFramePadding();
         ImGui::Text("CPU Usage: %5.1f%%", usage * 100);
         if(red) ImGui::PopStyleColor();
     }
@@ -46,8 +60,12 @@ static void window_contents()
         fps_i = (fps_i + 1) % fps_queue.size();
         fps = std::accumulate(fps_queue.begin(), fps_queue.end(), 0.f) * (1.f / fps_queue.size());
         ImGui::SameLine();
-        ImGui::Text("     FPS: %5.1f", fps);
+        ImGui::AlignTextToFramePadding();
+        ImGui::Text("     FPS: %5.1f     ", fps);
     }
+
+    ImGui::SameLine();
+    ImGui::Checkbox("Align to frames", &frame_based);
 
     constexpr auto plot_flags =
         ImPlotFlags_NoTitle |
@@ -61,8 +79,9 @@ static void window_contents()
         auto* plot = GetCurrentPlot();
         constexpr double ZOOM = 4.0;
         constexpr double IZOOM = 1.0 / ZOOM;
-        double n = double(arduboy->total_frames);
-        double m = n - arduboy->frame_cpu_usage.size();
+        double n = double(frame_based? arduboy->total_frames : arduboy->total_ms);
+        auto const& d = frame_based ? arduboy->frame_cpu_usage : arduboy->ms_cpu_usage;
+        double m = n - d.size();
         double w = plot->FrameRect.GetWidth();
 
         double z = plot->Axes[ImAxis_X1].Range.Size();
@@ -74,8 +93,10 @@ static void window_contents()
             ImPlotAxisFlags_NoHighlight |
             //ImPlotAxisFlags_NoDecorations |
             0;
-        SetupAxis(ImAxis_X1, "Frame", axis_flags);
+        SetupAxis(ImAxis_X1, frame_based ? "Frame" : "Time (s)", axis_flags);
         SetupAxis(ImAxis_Y1, nullptr, axis_flags);
+        if(!frame_based)
+            SetupAxisFormat(ImAxis_X1, xaxis_ms_formatter);
         SetupAxisFormat(ImAxis_Y1, yaxis_formatter);
 
         double lim_min = m;
@@ -103,13 +124,13 @@ static void window_contents()
         SetupFinish();
         PushStyleVar(ImPlotStyleVar_FillAlpha, 0.25f);
         PlotShaded("##usage",
-            arduboy->frame_cpu_usage.data(),
-            (int)arduboy->frame_cpu_usage.size(),
+            d.data(),
+            (int)d.size(),
             0.0, 1.0, m);
         PopStyleVar();
         PlotLine("##usage",
-            arduboy->frame_cpu_usage.data(),
-            (int)arduboy->frame_cpu_usage.size(),
+            d.data(),
+            (int)d.size(),
             1.0, m);
         EndPlot();
     }


### PR DESCRIPTION
Adds a toggle to the CPU Usage window to switch the plot between frame-aligned and time-based CPU usage.